### PR TITLE
Feature/RTLI-598: Debug utility fps UI performance monitor

### DIFF
--- a/FPSCounter.xcodeproj/project.pbxproj
+++ b/FPSCounter.xcodeproj/project.pbxproj
@@ -454,7 +454,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "ch.konoma.fps-counter";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -476,7 +476,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "ch.konoma.fps-counter";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -492,7 +492,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = "$(SRCROOT)/SampleApp/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "ch.konoma.fps-sample-app";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -507,7 +507,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = "$(SRCROOT)/SampleApp/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "ch.konoma.fps-sample-app";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Sources/FPSStatusBarViewController.swift
+++ b/Sources/FPSStatusBarViewController.swift
@@ -36,6 +36,7 @@ class FPSStatusBarViewController: UIViewController {
         self.label.frame = CGRect(x: labelOriginX, y: rect.maxY - font.lineHeight - 2.0, width: rect.width, height: font.lineHeight)
         self.label.autoresizingMask = [ .flexibleWidth, .flexibleTopMargin ]
         self.label.font = font
+        self.label.textColor = .black
         self.view.addSubview(self.label)
 
         self.fpsCounter.delegate = self
@@ -89,13 +90,10 @@ extension FPSStatusBarViewController: FPSCounterDelegate {
         switch fps {
         case 45...:
             self.view.backgroundColor = .green
-            self.label.textColor = .black
         case 35...:
             self.view.backgroundColor = .orange
-            self.label.textColor = .white
         default:
             self.view.backgroundColor = .red
-            self.label.textColor = .white
         }
         updateStatusBarFrame()
     }

--- a/Sources/FPSStatusBarViewController.swift
+++ b/Sources/FPSStatusBarViewController.swift
@@ -49,10 +49,11 @@ class FPSStatusBarViewController: UIViewController {
     override func loadView() {
         self.view = UIView(frame: CGRect(x: 0.0, y: 0.0, width: 100.0, height: 100.0))
 
-        let font = UIFont.boldSystemFont(ofSize: 10.0)
+        let font = UIFont.italicSystemFont(ofSize: 12)
         let rect = self.view.bounds.insetBy(dx: 10.0, dy: 0.0)
-
-        self.label.frame = CGRect(x: rect.origin.x, y: rect.maxY - font.lineHeight - 1.0, width: rect.width, height: font.lineHeight)
+        let statusBarFrame = getStatusBarFrame()
+        let labelOriginX = statusBarFrame.height > 24 ? rect.origin.x : (statusBarFrame.width/2.0) + 30
+        self.label.frame = CGRect(x: labelOriginX, y: rect.maxY - font.lineHeight - 2.0, width: rect.width, height: font.lineHeight)
         self.label.autoresizingMask = [ .flexibleWidth, .flexibleTopMargin ]
         self.label.font = font
         self.view.addSubview(self.label)
@@ -86,8 +87,16 @@ extension FPSStatusBarViewController: FPSCounterDelegate {
     @objc func fpsCounter(_ counter: FPSCounter, didUpdateFramesPerSecond fps: Int) {
         self.resignKeyWindowIfNeeded()
 
+        guard fps < 58 else {
+            FPSStatusBarViewController.statusBarWindow.isHidden = true
+            return
+        }
+        
+        FPSStatusBarViewController.statusBarWindow.isHidden = false
+        
         let milliseconds = 1000 / max(fps, 1)
-        self.label.text = "\(fps) FPS (\(milliseconds) milliseconds per frame)"
+        self.label.text = "\(fps) FPS (\(milliseconds)ms)"
+        self.label.textAlignment = .left
 
         switch fps {
         case 45...:

--- a/Sources/FPSStatusBarViewController.swift
+++ b/Sources/FPSStatusBarViewController.swift
@@ -56,7 +56,7 @@ class FPSStatusBarViewController: UIViewController {
         return window
     }()
     
-    private func getStatusBarFrame() -> CGRect {
+    fileprivate func getStatusBarFrame() -> CGRect {
         var statusBarFrame: CGRect
         if let statusBarFrameRect = view.window?.windowScene?.statusBarManager?.statusBarFrame {
             statusBarFrame = statusBarFrameRect
@@ -128,10 +128,9 @@ public extension FPSCounter {
         mode: RunLoop.Mode = .common
     ) {
         let window = FPSStatusBarViewController.statusBarWindow
-        window.frame = UIApplication.shared.windows.first?.windowScene?.statusBarManager?.statusBarFrame ?? CGRect.zero
-        window.isHidden = false
-
         if let controller = window.rootViewController as? FPSStatusBarViewController {
+            window.isHidden = false
+            window.frame = controller.getStatusBarFrame()
             controller.fpsCounter.startTracking(
                 inRunLoop: runloop,
                 mode: mode

--- a/Sources/FPSStatusBarViewController.swift
+++ b/Sources/FPSStatusBarViewController.swift
@@ -97,6 +97,7 @@ extension FPSStatusBarViewController: FPSCounterDelegate {
             self.view.backgroundColor = .red
             self.label.textColor = .white
         }
+        updateStatusBarFrame()
     }
 
     private func resignKeyWindowIfNeeded() {

--- a/Sources/FPSStatusBarViewController.swift
+++ b/Sources/FPSStatusBarViewController.swift
@@ -32,8 +32,10 @@ class FPSStatusBarViewController: UIViewController {
         let font = UIFont.italicSystemFont(ofSize: 12)
         let rect = self.view.bounds.insetBy(dx: 10.0, dy: 0.0)
         let statusBarFrame = getStatusBarFrame()
-        let labelOriginX = statusBarFrame.height > 24 ? rect.origin.x : (statusBarFrame.width/2.0) + 30
-        self.label.frame = CGRect(x: labelOriginX, y: rect.maxY - font.lineHeight - 2.0, width: rect.width, height: font.lineHeight)
+        let labelOriginX = statusBarFrame.height > 24 ? rect.origin.x : (statusBarFrame.width/4.0) - 20
+        let padding = UIDevice.current.userInterfaceIdiom == .pad ? 4.0 : 2.0
+        let labelOriginY = rect.maxY - font.lineHeight - padding
+        self.label.frame = CGRect(x: labelOriginX, y: labelOriginY , width: rect.width, height: font.lineHeight)
         self.label.autoresizingMask = [ .flexibleWidth, .flexibleTopMargin ]
         self.label.font = font
         self.label.textColor = .black


### PR DESCRIPTION
# Purpose
Fix FPS count label overlapping with status bar contents. Fix iOS 13 deprecated warnings.

# Reviewer Testing
- Run `pod install` command after switching branch.
- Cars app in debug mode build.
- See status bar colour to know the FPS level Green/Orange/Red to indicate the UI performance.

# Screenshots
|iPhone SE|iPhone 14 Pro Max|
|---|---|
|![Simulator Screenshot - iPhone SE (3rd generation) - 2023-06-21 at 11 14 16](https://github.com/trentf-carsales/fps-counter/assets/97424079/5dc2cef6-097c-425a-baa4-b426364588d8)|![Simulator Screenshot - iPhone 14 Pro Max - 2023-06-21 at 11 12 15](https://github.com/trentf-carsales/fps-counter/assets/97424079/6d502e6e-81a5-4635-aef5-5ccb1aeef510)|

|iPhone 13 Pro|iPhone 13 Pro with FPS|
|---|---|
|![Simulator Screenshot - iPhone 13 Pro - 2023-06-21 at 11 31 14](https://github.com/trentf-carsales/fps-counter/assets/97424079/1a0ad0e7-9cea-46cd-afd9-e7a57a23f7a0)|![Simulator Screenshot - iPhone 13 Pro - 2023-06-21 at 11 31 21](https://github.com/trentf-carsales/fps-counter/assets/97424079/3806a139-178d-4e32-a015-fdef880bd9e0)|

|iPad Pro (12 9-inch)|iPad Pro (12 9-inch) Landscape|
|---|---|
|![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-06-21 at 11 27 41](https://github.com/trentf-carsales/fps-counter/assets/97424079/08f66897-3373-4dc8-b0d0-bb663b33b19b)|![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-06-21 at 11 27 47](https://github.com/trentf-carsales/fps-counter/assets/97424079/3c349067-731c-4c46-838d-bdc4429baa7d)|

|iPad Pro (12 9-inch)|iPad Pro (12 9-inch) Landscape|
|---|---|
|![Simulator Screenshot - iPad Air (5th generation) - 2023-06-21 at 11 25 09](https://github.com/trentf-carsales/fps-counter/assets/97424079/f67e9f74-50cc-4122-a76b-bd22ba48cd84)|![Simulator Screenshot - iPad Air (5th generation) - 2023-06-21 at 11 25 17](https://github.com/trentf-carsales/fps-counter/assets/97424079/fe8eb4f9-2df6-4e0e-842c-2b3b7bce5548)|